### PR TITLE
Support CXX, AR, and AS override; DISABLE_ASM flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,17 +4,35 @@
 # AS = as
 # ASFLAGS =
 
+ifeq ($(shell uname),Darwin)
+	DISABLE_ASM=true
+endif
+
+ifeq ($(DISABLE_ASM),true)
+	EXTRA_CXXFLAGS = -DDISABLE_ASM
+else
+# Try to autodetect the target architecture and set ARCHDIR accordingly
+	ARCH = $(shell uname -m)
+	ARCHDIR = src/core/arch/$(ARCH)
+endif
+
 CXX = clang++
-CXXFLAGS = -std=c++17 -I./include -Ofast -fno-vectorize
+CXXFLAGS = -std=c++17 -I./include -Ofast -fno-vectorize -fPIE $(EXTRA_CXXFLAGS)
 AR = ar
 AS = as
 ASFLAGS =
 
-CXXFLAGS += -fPIE
+ifneq ($(CXX_OVERRIDE),)
+	CXX = $(CXX_OVERRIDE)
+endif
 
-# Try to autodetect the target architecture and set ARCHDIR accordingly
-ARCH = $(shell uname -m)
-ARCHDIR = src/core/arch/$(ARCH)
+ifneq ($(AR_OVERRIDE),)
+	AR = $(AR_OVERRIDE)
+endif
+
+ifneq ($(AS_OVERRIDE),)
+	AS = $(AS_OVERRIDE)
+endif
 
 # Comment out the above and uncomment the below for embedded build
 
@@ -24,10 +42,6 @@ ARCHDIR = src/core/arch/$(ARCH)
 # AS = arm-none-eabi-as
 # ASFLAGS = -mcpu=cortex-m0plus -mlittle-endian -mthumb -mfloat-abi=soft
 # ARCHDIR = src/core/arch/armv6_m
-
-ifeq ($(ARCH),arm64)
-CXXFLAGS += -DDISABLE_ASM
-endif
 
 PAIRING_CPP_SOURCES = $(wildcard src/core/*.cpp) $(wildcard src/bls12_381/*.cpp) $(wildcard src/wkdibe/*.cpp) $(wildcard src/lqibe/*.cpp) $(wildcard $(ARCHDIR)/*.cpp)
 PAIRING_ASM_SOURCES = $(wildcard $(ARCHDIR)/*.s)


### PR DESCRIPTION
This commit updates the Makefile to allow the caller to set overrides for CXX, AR, and AS. It additionally reworks the logic for disabling assembly to require the user to set the DISABLE_ASM environment variable.